### PR TITLE
Use Swift's Syntactic Sugar

### DIFF
--- a/HandyJSON/HelpingMapper.swift
+++ b/HandyJSON/HelpingMapper.swift
@@ -21,7 +21,7 @@ import Foundation
 
 public class HelpingMapper {
 
-    private var mapping = Dictionary<Int, (String?, ((String) -> ())?)>()
+    private var mapping = [Int: (String?, ((String) -> ())?)]()
 
     public func specify<T>(property: inout T, name: String) {
         let key = withUnsafePointer(to: &property, { return $0 }).hashValue

--- a/HandyJSON/JSONDeserializer.swift
+++ b/HandyJSON/JSONDeserializer.swift
@@ -57,7 +57,7 @@ public class JSONDeserializer<T: HandyJSON> {
         return nil
     }
 
-    public static func deserializeModelArrayFrom(json: String?) -> Array<T?>? {
+    public static func deserializeModelArrayFrom(json: String?) -> [T?]? {
         guard let _json = json else {
             return nil
         }

--- a/HandyJSON/JSONSerializer.swift
+++ b/HandyJSON/JSONSerializer.swift
@@ -27,7 +27,7 @@ public protocol ModelTransformerProtocol {
 
     func toPrettifyJSON() -> String?
 
-    func toSimpleDictionary() -> Dictionary<String, Any>?
+    func toSimpleDictionary() -> [String: Any]?
 }
 
 public protocol ArrayTransformerProtocol {
@@ -36,7 +36,7 @@ public protocol ArrayTransformerProtocol {
 
     func toPrettifyJSON() -> String?
 
-    func toSimpleArray() -> Array<Any>?
+    func toSimpleArray() -> [Any]?
 }
 
 public protocol DictionaryTransformerProtocol {
@@ -45,7 +45,7 @@ public protocol DictionaryTransformerProtocol {
 
     func toPrettifyJSON() -> String?
 
-    func toSimpleDictionary() -> Dictionary<String, Any>?
+    func toSimpleDictionary() -> [String: Any]?
 }
 
 class GenericObjectTransformer: ModelTransformerProtocol, ArrayTransformerProtocol, DictionaryTransformerProtocol {
@@ -56,16 +56,16 @@ class GenericObjectTransformer: ModelTransformerProtocol, ArrayTransformerProtoc
         self.object = object
     }
 
-    public func toSimpleArray() -> Array<Any>? {
+    public func toSimpleArray() -> [Any]? {
         if let _object = self.object, let result = GenericObjectTransformer.transformToSimpleObject(object: _object) {
-            return result as? Array<Any>
+            return result as? [Any]
         }
         return nil
     }
 
-    public func toSimpleDictionary() -> Dictionary<String, Any>? {
+    public func toSimpleDictionary() -> [String: Any]? {
         if let _object = self.object, let result = GenericObjectTransformer.transformToSimpleObject(object: _object) {
-            return result as? Dictionary<String, Any>
+            return result as? [String: Any]
         }
         return nil
     }
@@ -175,7 +175,7 @@ extension GenericObjectTransformer {
             let json = String(describing: object)
             return json
         case is ArrayTypeProtocol.Type:
-            let array = object as! Array<Any>
+            let array = object as! [Any]
             var json = ""
             array.enumerated().forEach({ (index, element) in
                 if index != 0 {
@@ -185,7 +185,7 @@ extension GenericObjectTransformer {
             })
             return "[" + json + "]"
         case is DictionaryTypeProtocol.Type:
-            let dict = object as! Dictionary<String, Any>
+            let dict = object as! [String: Any]
             var json = ""
             dict.enumerated().forEach({ (index, kv) in
                 if index != 0 {
@@ -210,11 +210,11 @@ public class JSONSerializer {
         return GenericObjectTransformer(of: model)
     }
 
-    public static func serialize(array: Array<Any>?) -> ArrayTransformerProtocol {
+    public static func serialize(array: [Any]?) -> ArrayTransformerProtocol {
         return GenericObjectTransformer(of: array)
     }
 
-    public static func serialize(array: Array<AnyObject>?) -> ArrayTransformerProtocol {
+    public static func serialize(array: [AnyObject]?) -> ArrayTransformerProtocol {
         return GenericObjectTransformer(of: array)
     }
 
@@ -222,11 +222,11 @@ public class JSONSerializer {
         return GenericObjectTransformer(of: array)
     }
 
-    public static func serialize(dict: Dictionary<String, Any>?) -> DictionaryTransformerProtocol {
+    public static func serialize(dict: [String: Any]?) -> DictionaryTransformerProtocol {
         return GenericObjectTransformer(of: dict)
     }
 
-    public static func serialize(dict: Dictionary<String, AnyObject>?) -> DictionaryTransformerProtocol {
+    public static func serialize(dict: [String: AnyObject]?) -> DictionaryTransformerProtocol {
         return GenericObjectTransformer(of: dict)
     }
 

--- a/HandyJSON/Property.swift
+++ b/HandyJSON/Property.swift
@@ -108,7 +108,7 @@ extension Array: ArrayTypeProtocol {
         return Element.self
     }
 
-    static func castArrayType(arr: [Any]) -> Array<Element> {
+    static func castArrayType(arr: [Any]) -> [Element] {
         return arr.map({ (p) -> Element in
             return p as! Element
         })
@@ -131,8 +131,8 @@ extension Dictionary: DictionaryTypeProtocol {
         return Value.self
     }
 
-    static func castDictionaryType(dict: [String: Any]) -> Dictionary<Key, Value> {
-        var result = Dictionary<Key, Value>()
+    static func castDictionaryType(dict: [String: Any]) -> [Key: Value] {
+        var result = [Key: Value]()
         dict.forEach { (key, value) in
             if let sKey = key as? Key, let sValue = value as? Value {
                 result[sKey] = sValue

--- a/HandyJSONTests/ClassObjectTest.swift
+++ b/HandyJSONTests/ClassObjectTest.swift
@@ -54,8 +54,8 @@ class ClassObjectTest: XCTestCase {
     func testClassWithArrayProperty() {
         class B: NSObject, HandyJSON {
             var id: Int?
-            var arr1: Array<Int>?
-            var arr2: Array<String>?
+            var arr1: [Int]?
+            var arr2: [String]?
 
             required override init() {}
         }
@@ -75,8 +75,8 @@ class ClassObjectTest: XCTestCase {
     func testClassWithImplicitlyUnwrappedOptionalProperty() {
         class C: NSObject, HandyJSON {
             var id: Int?
-            var arr1: Array<Int?>!
-            var arr2: Array<String>?
+            var arr1: [Int?]!
+            var arr2: [String]?
 
             required override init() {}
         }
@@ -96,17 +96,17 @@ class ClassObjectTest: XCTestCase {
     func testClassWithDummyProperty() {
         class C: NSObject, HandyJSON {
             var id: Int?
-            var arr1: Array<Int?>!
-            var arr2: Array<String>?
+            var arr1: [Int?]!
+            var arr2: [String]?
 
             required override init() {}
         }
         class D: HandyJSON {
             var dummy1: String?
             var id: Int!
-            var arr1: Array<Int>?
+            var arr1: [Int]?
             var dummy2: C?
-            var arr2: Array<String> = Array<String>()
+            var arr2: [String] = [String]()
             var dummy3: C!
 
             required init() {}
@@ -127,8 +127,8 @@ class ClassObjectTest: XCTestCase {
     func testClassWithDummyJsonField() {
         class E: HandyJSON {
             var id: Int?
-            var arr1: Array<Int?>!
-            var arr2: Array<String>?
+            var arr1: [Int?]!
+            var arr2: [String]?
 
             required init() {}
         }

--- a/HandyJSONTests/SerializeToJSONTests.swift
+++ b/HandyJSONTests/SerializeToJSONTests.swift
@@ -214,7 +214,7 @@ class serializeToJSONTests: XCTestCase {
             var a: String?
             var b: Int?
             var c: [Double]?
-            var d: Dictionary<String, String>?
+            var d: [String: String]?
 
             init() {
                 self.a = "hello"
@@ -244,7 +244,7 @@ class serializeToJSONTests: XCTestCase {
             var a: String?
             var b: Int?
             var c: [Double]?
-            var d: Dictionary<String, String>?
+            var d: [String: String]?
 
             init() {
                 self.a = "hello"

--- a/HandyJSONTests/StructObjectTest.swift
+++ b/HandyJSONTests/StructObjectTest.swift
@@ -52,8 +52,8 @@ class StructObjectTest: XCTestCase {
     func testStructWithArrayProperty() {
         struct B: HandyJSON {
             var id: Int?
-            var arr1: Array<Int>?
-            var arr2: Array<String>?
+            var arr1: [Int]?
+            var arr2: [String]?
         }
 
         let jsonString = "{\"id\":123456,\"arr1\":[1,2,3,4,5,6],\"arr2\":[\"a\",\"b\",\"c\",\"d\",\"e\"]}"
@@ -71,8 +71,8 @@ class StructObjectTest: XCTestCase {
     func testStructWithiImpliicitlyUnwrappedOptionalProperty() {
         struct C: HandyJSON {
             var id: Int?
-            var arr1: Array<Int?>!
-            var arr2: Array<String?>?
+            var arr1: [Int?]!
+            var arr2: [String?]?
         }
 
         let jsonString = "{\"id\":123456,\"arr1\":[1,2,3,4,5,6],\"arr2\":[\"a\",\"b\",\"c\",\"d\",\"e\"]}"
@@ -90,15 +90,15 @@ class StructObjectTest: XCTestCase {
     func testStructWithDummyProperty() {
         struct C: HandyJSON {
             var id: Int?
-            var arr1: Array<Int?>!
-            var arr2: Array<String?>?
+            var arr1: [Int?]!
+            var arr2: [String?]?
         }
         struct D: HandyJSON {
             var dummy1: String?
             var id: Int!
-            var arr1: Array<Int>?
+            var arr1: [Int]?
             var dummy2: C?
-            var arr2: Array<String> = Array<String>()
+            var arr2: [String] = [String]()
             var dumimy3: C!
         }
 
@@ -117,8 +117,8 @@ class StructObjectTest: XCTestCase {
     func testStructWithiDummyiJsonField() {
         struct E: HandyJSON {
             var id: Int?
-            var arr1: Array<Int?>!
-            var arr2: Array<String?>?
+            var arr1: [Int?]!
+            var arr2: [String?]?
         }
 
         let jsonString = "{\"id\":123456,\"dummy1\":23334,\"arr1\":[1,2,3,4,5,6],\"dummy2\":\"string\",\"arr2\":[\"a\",\"b\",\"c\",\"d\",\"e\"]}"
@@ -136,8 +136,8 @@ class StructObjectTest: XCTestCase {
     func testStructWithiDesiginatePath() {
         struct F: HandyJSON {
             var id: Int?
-            var arr1: Array<Int?>!
-            var arr2: Array<String?>?
+            var arr1: [Int?]!
+            var arr2: [String?]?
         }
 
         let jsonString = "{\"data\":{\"result\":{\"id\":123456,\"arr1\":[1,2,3,4,5,6],\"arr2\":[\"a\",\"b\",\"c\",\"d\",\"e\"]}},\"code\":200}"


### PR DESCRIPTION
Use the shortcut versions of type declarations over the full generics syntax.