### PR TITLE
Swift 4 warnings

### DIFF
--- a/Source/HexColorTransform.swift
+++ b/Source/HexColorTransform.swift
@@ -34,7 +34,7 @@ open class HexColorTransform: TransformType {
 	open func transformFromJSON(_ value: Any?) -> Object? {
 		if let rgba = value as? String {
 			if rgba.hasPrefix("#") {
-				let index = rgba.characters.index(rgba.startIndex, offsetBy: 1)
+				let index = rgba.index(rgba.startIndex, offsetBy: 1)
 				let hex = String(rgba[index...])
 				return getColor(hex: hex)
 			} else {
@@ -78,7 +78,7 @@ open class HexColorTransform: TransformType {
 		let scanner = Scanner(string: hex)
 		var hexValue: CUnsignedLongLong = 0
 		if scanner.scanHexInt64(&hexValue) {
-			switch (hex.characters.count) {
+			switch (hex.count) {
 			case 3:
 				red   = CGFloat((hexValue & 0xF00) >> 8)       / 15.0
 				green = CGFloat((hexValue & 0x0F0) >> 4)       / 15.0


### PR DESCRIPTION
Hello! First of all, thanks for this amazing solution. It just became my main deserialization tool! 

**Changes**
Characters is deprecated in Swift 4.
(I just realized that I forked `4.0.0-beta.1` instead of `1.8.0`. My main motivation for this PR was to fix the compile error in Swift 4 [`Integer` was renamed to `BinaryInteger`], which seems to be fixed in this version).

Cheers 🍻
