### PR TITLE
Fix Swift 4 warnings

### DIFF
--- a/Source/HexColorTransform.swift
+++ b/Source/HexColorTransform.swift
@@ -34,7 +34,7 @@ open class HexColorTransform: TransformType {
 	open func transformFromJSON(_ value: Any?) -> Object? {
 		if let rgba = value as? String {
 			if rgba.hasPrefix("#") {
-				let index = rgba.characters.index(rgba.startIndex, offsetBy: 1)
+				let index = rgba.index(rgba.startIndex, offsetBy: 1)
 				let hex = String(rgba[index...])
 				return getColor(hex: hex)
 			} else {
@@ -78,7 +78,7 @@ open class HexColorTransform: TransformType {
 		let scanner = Scanner(string: hex)
 		var hexValue: CUnsignedLongLong = 0
 		if scanner.scanHexInt64(&hexValue) {
-			switch (hex.characters.count) {
+			switch (hex.count) {
 			case 3:
 				red   = CGFloat((hexValue & 0xF00) >> 8)       / 15.0
 				green = CGFloat((hexValue & 0x0F0) >> 4)       / 15.0


### PR DESCRIPTION
'characters' is deprecated: Please use String or substring directly.