### PR TITLE
Fixed an out-of-bounds crash in swift 4.1

### DIFF
--- a/Source/NominalType.swift
+++ b/Source/NominalType.swift
@@ -31,7 +31,11 @@ extension NominalType {
             // swift class created dynamically in objc-runtime didn't have valid nominalTypeDescriptor
             return nil
         }
+        #if swift(>=4.1)
+        return NominalTypeDescriptor(pointer: relativePointer(base: base, offset: base.pointee - base.hashValue))
+        #else
         return NominalTypeDescriptor(pointer: relativePointer(base: base, offset: base.pointee))
+        #endif
     }
 
     var fieldTypes: [Any.Type]? {


### PR DESCRIPTION
修正在swift 4.1下的因为NominalTypeDescriptor越界而导致的崩溃问题
该问题会导致基础类型的数据无法反序列化
对应issues #237 #239 #240 