### PR TITLE
 fix:修复长数字转字符串变成科学计数问题

### DIFF
--- a/Source/BuiltInBasicType.swift
+++ b/Source/BuiltInBasicType.swift
@@ -113,6 +113,14 @@ extension FloatPropertyProtocol {
 extension Float: FloatPropertyProtocol {}
 extension Double: FloatPropertyProtocol {}
 
+fileprivate let formatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.usesGroupingSeparator = false
+    formatter.numberStyle = .decimal
+    formatter.maximumFractionDigits = 100
+    return formatter
+}()
+
 extension String: _BuiltInBasicType {
 
     static func _transform(from object: Any) -> String? {
@@ -128,7 +136,7 @@ extension String: _BuiltInBasicType {
                     return "false"
                 }
             }
-            return String(format:"%g", num.doubleValue)
+            return formatter.string(from: num)
         case _ as NSNull:
             return nil
         default:


### PR DESCRIPTION
使用%g会导致长数字科学计数法展示，使用NumberFormatter转换可以解决余数问题，长数字也可正常展示