### PR TITLE
feat: willStartMapping feature

### DIFF
--- a/Source/ExtendCustomModelType.swift
+++ b/Source/ExtendCustomModelType.swift
@@ -10,12 +10,14 @@ import Foundation
 
 public protocol _ExtendCustomModelType: _Transformable {
     init()
+    mutating func willStartMapping()
     mutating func mapping(mapper: HelpingMapper)
     mutating func didFinishMapping()
 }
 
 extension _ExtendCustomModelType {
 
+    public mutating func willStartMapping() {}
     public mutating func mapping(mapper: HelpingMapper) {}
     public mutating func didFinishMapping() {}
 }
@@ -126,6 +128,7 @@ extension _ExtendCustomModelType {
         } else {
             instance = Self.init()
         }
+        instance.willStartMapping()
         _transform(dict: dict, to: &instance)
         instance.didFinishMapping()
         return instance

--- a/Tests/HandyJSONTests/OtherFeaturesTest.swift
+++ b/Tests/HandyJSONTests/OtherFeaturesTest.swift
@@ -337,6 +337,42 @@ class StructObjectTest: XCTestCase {
         let jsonstr = a.toJSONString()
         XCTAssert(jsonstr == "{\"p\":[{\"name\":\"dddd\"},{\"name\":\"dddd\"}]}")
     }
+    
+    func testWillStartMappingForClass() {
+        class A: HandyJSON {
+            var name: String?
+            var upperName: String?
+            required init() {}
+            
+            func willStartMapping() {
+                name = "AAA"
+                upperName = "AAA"
+            }
+        }
+        
+        let jsonString = "{\"name\":\"HandyJson\"}"
+        let a = A.deserialize(from: jsonString)!
+        XCTAssertEqual(a.name, "HandyJson")
+        XCTAssertEqual(a.upperName, "AAA")
+    }
+    
+    func testWillStartMappingForStruct() {
+        struct A: HandyJSON {
+            var name: String?
+            var upperName: String?
+            
+            mutating func willStartMapping() {
+                name = "AAA"
+                upperName = "AAA"
+            }
+        }
+        
+        let jsonString = "{\"name\":\"HandyJson\"}"
+        let a = A.deserialize(from: jsonString)!
+        XCTAssertEqual(a.name, "HandyJson")
+        XCTAssertEqual(a.upperName, "AAA")
+    }
+
 
     func testDidFinishMappingForClass() {
         class A: HandyJSON {


### PR DESCRIPTION
添加 `willStartMapping` 方法，在对象初始化后、解析前提供修改时机