### PR TITLE
Present null for property with nil value

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,19 @@ class BasicTypes: HandyJSON {
 }
 ```
 
+## Q: How to present a `null` value of `nil` property when serialize to JSON?
 
+In `mapping(mapper: HelpingMapper)`, use `mapper.nullPresent` to apply null present for property
+
+```swift
+class Animal: HandyJSON {
+    var name: String?
+    var owner: String?
+    func mapping(mapper: HelpingMapper) {
+        mapper.nullPresent(self.owner)
+    }
+}
+```
 
 # License
 

--- a/Source/ExtendCustomModelType.swift
+++ b/Source/ExtendCustomModelType.swift
@@ -235,7 +235,7 @@ extension _ExtendCustomModelType {
         for (key, property) in properties {
             var realKey = key
             var realValue = property.0
-
+            var useNullValueIfNeeded = false
             if let info = property.1 {
                 if info.bridged, let _value = (instance as! NSObject).value(forKey: key) {
                     realValue = _value
@@ -245,6 +245,10 @@ extension _ExtendCustomModelType {
                     continue
                 }
 
+                if mapper.propertyPresentNullValue(key: Int(bitPattern: info.address)) {
+                    useNullValueIfNeeded = true
+                }
+                
                 if let mappingHandler = mapper.getMappingHandler(key: Int(bitPattern: info.address)) {
                     // if specific key is set, replace the label
                     if let mappingPaths = mappingHandler.mappingPaths, mappingPaths.count > 0 {
@@ -264,6 +268,10 @@ extension _ExtendCustomModelType {
             if let typedValue = realValue as? _Transformable {
                 if let result = self._serializeAny(object: typedValue) {
                     dict[realKey] = result
+                    continue
+                }
+                else if useNullValueIfNeeded {
+                    dict[realKey] = NSNull()
                     continue
                 }
             }

--- a/Source/HelpingMapper.swift
+++ b/Source/HelpingMapper.swift
@@ -85,6 +85,7 @@ public class HelpingMapper {
     
     private var mappingHandlers = [Int: MappingPropertyHandler]()
     private var excludeProperties = [Int]()
+    private var nullPresentProperties = [Int]()
     
     internal func getMappingHandler(key: Int) -> MappingPropertyHandler? {
         return self.mappingHandlers[key]
@@ -92,6 +93,10 @@ public class HelpingMapper {
     
     internal func propertyExcluded(key: Int) -> Bool {
         return self.excludeProperties.contains(key)
+    }
+    
+    internal func propertyPresentNullValue(key: Int) -> Bool {
+        return self.nullPresentProperties.contains(key)
     }
     
     public func specify<T>(property: inout T, name: String) {
@@ -126,6 +131,14 @@ public class HelpingMapper {
     
     public func exclude<T>(property: inout T) {
         self._exclude(property: &property)
+    }
+    
+    public func nullPresent<T>(property: inout T) {
+        let pointer = withUnsafePointer(to: &property, { return $0 })
+        let iPointer = Int(bitPattern: pointer)
+        if !self.excludeProperties.contains(iPointer) && !nullPresentProperties.contains(iPointer) {
+            nullPresentProperties.append(iPointer)
+        }
     }
     
     fileprivate func addCustomMapping(key: Int, mappingInfo: MappingPropertyHandler) {

--- a/Tests/HandyJSONTests/OtherFeaturesTest.swift
+++ b/Tests/HandyJSONTests/OtherFeaturesTest.swift
@@ -404,4 +404,19 @@ class StructObjectTest: XCTestCase {
         let a = A.deserialize(from: jsonString)!
         XCTAssertEqual(a.upperName, "HANDYJSON")
     }
+    
+    func testNullPresentValue() {
+        class A: HandyJSON {
+            var name: String?
+            required init() {}
+            
+            func mapping(mapper: HelpingMapper) {
+                mapper.nullPresent(property: &self.name)
+            }
+        }
+        
+        let a = A()
+        let jsonString = a.toJSONString()!
+        XCTAssertEqual(jsonString, "{\"name\":null}")
+    }
 }


### PR DESCRIPTION
Currently, all property with `nil` value will be ignore when serialized. But in some case, it need present a `null` text (for example: send request update data of record to server).
So I add a little bit codes to help user can add property which should be present `null` when value of it is `nil`.