### PR TITLE
Solving issues with SPM 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - OSX_SDK=macosx10.12
 
 before_install:
-  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - gem install xcpretty --no-document --quiet
 
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.2
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
     - OSX_FRAMEWORK_SCHEME="HandyJSON Mac"
     - TVOS_FRAMEWORK_SCHEME="HandyJSON tvOS"
     - WATCHOS_FRAMEWORK_SCHEME="HandyJSON watchOS"
-    - IOS_SDK=iphonesimulator12.0
-    - OSX_SDK=macosx10.12
+    - IOS_SDK=iphonesimulator12.2
+    - OSX_SDK=macosx10.14
 
 before_install:
   - gem install xcpretty --no-document --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -showsdks
+  - echo "Applying fix for rdar://49326587 see https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_1_release_notes?language=objc"
+  - sudo mkdir '/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 9.3.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift'
 
   - xcodebuild -scheme "$IOS_FRAMEWORK_SCHEME" -sdk "$IOS_SDK" -destination "platform=iOS Simulator,OS=12.0,name=iPhone XS Max" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c
 

--- a/HandyJSON.podspec
+++ b/HandyJSON.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
     s.author = {'xuyecan' => 'xuyecan@gmail.com'}
     s.license = 'Apache License 2.0'
     s.requires_arc = true
-    s.version = '5.0.0'
+    s.version = '5.0.1'
     s.homepage = "https://github.com/alibaba/handyjson"
     s.name = "HandyJSON"
 

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "HandyJSON",
+    products: [
+        .library(name: "HandyJSON", targets: ["HandyJSON"]),
+    ],
+    targets: [
+        .target(
+            name: "HandyJSON",
+	    dependencies: [],
+	    path: "Source"
+        )
+    ]
+)
+

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ An overview of types supported can be found at file: [BasicTypes.swift](./HandyJ
 
 # Installation
 
-**To use with Swift 5.0 ( Xcode 10.2 ), version == 5.0.0**
+**To use with Swift 5.0 ( Xcode 10.2 ), version == 5.0.1**
 
 **To use with Swift 4.2 ( Xcode 10 ), version == 4.2.0**
 
@@ -123,7 +123,7 @@ For Legacy Swift2.x support, take a look at the [swift2 branch](https://github.c
 Add the following line to your `Podfile`:
 
 ```
-pod 'HandyJSON', '~> 5.0.0'
+pod 'HandyJSON', '~> 5.0.1'
 ```
 
 Then, run the following command:
@@ -137,7 +137,7 @@ $ pod install
 You can add a dependency on `HandyJSON` by adding the following line to your `Cartfile`:
 
 ```
-github "alibaba/HandyJSON" ~> 5.0.0
+github "alibaba/HandyJSON" ~> 5.0.1
 ```
 
 ## Manually


### PR DESCRIPTION
I ran into some issue with Swift Package Manager version 5.0.0. It complained first about "dependency graph is unresolvable" then it could not find the source. I resolved these issues by adding a `Package@swift-4.swift` file with some more information. 

To be consistent I tagged the update as 5.0.1 and updated the versions in the podspec and README. Hopefully this is useful. 