### PR TITLE
add swift_version

### DIFF
--- a/HandyJSON.podspec
+++ b/HandyJSON.podspec
@@ -18,5 +18,6 @@ Pod::Spec.new do |s|
     s.watchos.deployment_target = '2.0'
     s.tvos.deployment_target = '9.0'
 
+    s.swift_version = '5.0'
     s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
 end


### PR DESCRIPTION
in some 3th part tools, 'pod_target_xcconfig' not work, it's necessary to add the 's.swift_version'