### PR TITLE
增加transformer接口，解决字符串转字典功能无法实现的问题

### DIFF
--- a/Source/BuiltInBridgeType.swift
+++ b/Source/BuiltInBridgeType.swift
@@ -10,27 +10,33 @@ import Foundation
 
 protocol _BuiltInBridgeType: _Transformable {
 
-    static func _transform(from object: Any) -> _BuiltInBridgeType?
-    func _plainValue() -> Any?
+    static func _transform(from object: Any, transformer: _Transformer?) -> _BuiltInBridgeType?
+    func _plainValue(transformer: _Transformer?) -> Any?
 }
 
 extension NSString: _BuiltInBridgeType {
 
-    static func _transform(from object: Any) -> _BuiltInBridgeType? {
-        if let str = String.transform(from: object) {
+    static func _transform(from object: Any, transformer: _Transformer?) -> _BuiltInBridgeType? {
+        if let str = String.transform(from: object, transformer: transformer) {
             return NSString(string: str)
         }
         return nil
     }
 
-    func _plainValue() -> Any? {
+    func _plainValue(transformer: _Transformer?) -> Any? {
+        if let result = transformer?.plainValue(from: self) {
+            return result
+        }
         return self
     }
 }
 
 extension NSNumber: _BuiltInBridgeType {
 
-    static func _transform(from object: Any) -> _BuiltInBridgeType? {
+    static func _transform(from object: Any, transformer: _Transformer?) -> _BuiltInBridgeType? {
+        if let result = transformer?.transform(from: object, type: self) {
+            return result
+        }
         switch object {
         case let num as NSNumber:
             return num
@@ -51,29 +57,38 @@ extension NSNumber: _BuiltInBridgeType {
         }
     }
 
-    func _plainValue() -> Any? {
+    func _plainValue(transformer: _Transformer?) -> Any? {
+        if let result = transformer?.plainValue(from: self) {
+            return result
+        }
         return self
     }
 }
 
 extension NSArray: _BuiltInBridgeType {
     
-    static func _transform(from object: Any) -> _BuiltInBridgeType? {
+    static func _transform(from object: Any, transformer: _Transformer?) -> _BuiltInBridgeType? {
+        if let result = transformer?.transform(from: object, type: self) {
+            return result
+        }
         return object as? NSArray
     }
 
-    func _plainValue() -> Any? {
-        return (self as? Array<Any>)?.plainValue()
+    func _plainValue(transformer: _Transformer?) -> Any? {
+        return (self as? Array<Any>)?.plainValue(transformer: transformer)
     }
 }
 
 extension NSDictionary: _BuiltInBridgeType {
     
-    static func _transform(from object: Any) -> _BuiltInBridgeType? {
+    static func _transform(from object: Any, transformer: _Transformer?) -> _BuiltInBridgeType? {
+        if let result = transformer?.transform(from: object, type: self) {
+            return result
+        }
         return object as? NSDictionary
     }
 
-    func _plainValue() -> Any? {
-        return (self as? Dictionary<String, Any>)?.plainValue()
+    func _plainValue(transformer: _Transformer?) -> Any? {
+        return (self as? Dictionary<String, Any>)?.plainValue(transformer: transformer)
     }
 }

--- a/Source/Custom/Transformer.swift
+++ b/Source/Custom/Transformer.swift
@@ -1,0 +1,22 @@
+//
+//  Transformer.swift
+//  HandyJSON
+//
+//  Created by 熊朝伟 on 2021/1/15.
+//
+
+import Foundation
+
+public protocol _Transformer {
+    func transform<K,V>(from object: Any, type: [K:V].Type) -> [K:V]?
+    func transform<T>(from object: Any, type: [T].Type) -> [T]?
+    func transform<T>(from object: Any, type: T.Type) -> T?
+    func plainValue<T>(from object: T) -> Any?
+}
+
+extension _Transformer {
+    public func transform<K,V>(from object: Any, type: [K:V].Type) -> [K:V]? { nil }
+    public func transform<T>(from object: Any, type: [T].Type) -> [T]? { nil }
+    public func transform<T>(from object: Any, type: T.Type) -> T? { nil }
+    public func plainValue<T>(from object: T) -> Any? { nil }
+}

--- a/Source/Deserializer.swift
+++ b/Source/Deserializer.swift
@@ -63,33 +63,33 @@ public class JSONDeserializer<T: HandyJSON> {
 
     /// Finds the internal dictionary in `dict` as the `designatedPath` specified, and map it to a Model
     /// `designatedPath` is a string like `result.data.orderInfo`, which each element split by `.` represents key of each layer, or nil
-    public static func deserializeFrom(dict: NSDictionary?, designatedPath: String? = nil) -> T? {
-        return deserializeFrom(dict: dict as? [String: Any], designatedPath: designatedPath)
+    public static func deserializeFrom(dict: NSDictionary?, designatedPath: String? = nil, transformer: _Transformer? = nil) -> T? {
+        return deserializeFrom(dict: dict as? [String: Any], designatedPath: designatedPath, transformer: transformer)
     }
 
     /// Finds the internal dictionary in `dict` as the `designatedPath` specified, and map it to a Model
     /// `designatedPath` is a string like `result.data.orderInfo`, which each element split by `.` represents key of each layer, or nil
-    public static func deserializeFrom(dict: [String: Any]?, designatedPath: String? = nil) -> T? {
+    public static func deserializeFrom(dict: [String: Any]?, designatedPath: String? = nil, transformer: _Transformer? = nil) -> T? {
         var targetDict = dict
         if let path = designatedPath {
             targetDict = getInnerObject(inside: targetDict, by: path) as? [String: Any]
         }
         if let _dict = targetDict {
-            return T._transform(dict: _dict) as? T
+            return T._transform(dict: _dict, transformer: transformer) as? T
         }
         return nil
     }
 
     /// Finds the internal JSON field in `json` as the `designatedPath` specified, and converts it to Model
     /// `designatedPath` is a string like `result.data.orderInfo`, which each element split by `.` represents key of each layer, or nil
-    public static func deserializeFrom(json: String?, designatedPath: String? = nil) -> T? {
+    public static func deserializeFrom(json: String?, designatedPath: String? = nil, transformer: _Transformer? = nil) -> T? {
         guard let _json = json else {
             return nil
         }
         do {
             let jsonObject = try JSONSerialization.jsonObject(with: _json.data(using: String.Encoding.utf8)!, options: .allowFragments)
             if let jsonDict = jsonObject as? NSDictionary {
-                return self.deserializeFrom(dict: jsonDict, designatedPath: designatedPath)
+                return self.deserializeFrom(dict: jsonDict, designatedPath: designatedPath, transformer: transformer)
             }
         } catch let error {
             InternalLogger.logError(error)
@@ -99,13 +99,13 @@ public class JSONDeserializer<T: HandyJSON> {
 
     /// Finds the internal dictionary in `dict` as the `designatedPath` specified, and use it to reassign an exist model
     /// `designatedPath` is a string like `result.data.orderInfo`, which each element split by `.` represents key of each layer, or nil
-    public static func update(object: inout T, from dict: [String: Any]?, designatedPath: String? = nil) {
+    public static func update(object: inout T, from dict: [String: Any]?, designatedPath: String? = nil, transformer: _Transformer? = nil) {
         var targetDict = dict
         if let path = designatedPath {
             targetDict = getInnerObject(inside: targetDict, by: path) as? [String: Any]
         }
         if let _dict = targetDict {
-            T._transform(dict: _dict, to: &object)
+            T._transform(dict: _dict, to: &object, transformer: transformer)
         }
     }
 

--- a/Source/EnumType.swift
+++ b/Source/EnumType.swift
@@ -10,22 +10,28 @@ import Foundation
 
 public protocol _RawEnumProtocol: _Transformable {
 
-    static func _transform(from object: Any) -> Self?
-    func _plainValue() -> Any?
+    static func _transform(from object: Any, transformer: _Transformer?) -> Self?
+    func _plainValue(transformer: _Transformer?) -> Any?
 }
 
 extension RawRepresentable where Self: _RawEnumProtocol {
 
-    public static func _transform(from object: Any) -> Self? {
+    public static func _transform(from object: Any, transformer: _Transformer?) -> Self? {
+        if let result = transformer?.transform(from: object, type: self) {
+            return result
+        }
         if let transformableType = RawValue.self as? _Transformable.Type {
-            if let typedValue = transformableType.transform(from: object) {
+            if let typedValue = transformableType.transform(from: object, transformer: transformer) {
                 return Self(rawValue: typedValue as! RawValue)
             }
         }
         return nil
     }
 
-    public func _plainValue() -> Any? {
+    public func _plainValue(transformer: _Transformer?) -> Any? {
+        if let result = transformer?.plainValue(from: self) {
+            return result
+        }
         return self.rawValue
     }
 }

--- a/Source/Export.swift
+++ b/Source/Export.swift
@@ -13,3 +13,5 @@ public protocol HandyJSONCustomTransformable: _ExtendCustomBasicType {}
 public protocol HandyJSON: _ExtendCustomModelType {}
 
 public protocol HandyJSONEnum: _RawEnumProtocol {}
+
+public protocol HandyJSONTransformer: _Transformer {}

--- a/Source/ExtendCustomBasicType.swift
+++ b/Source/ExtendCustomBasicType.swift
@@ -23,6 +23,6 @@
 
 public protocol _ExtendCustomBasicType: _Transformable {
 
-    static func _transform(from object: Any) -> Self?
-    func _plainValue() -> Any?
+    static func _transform(from object: Any, transformer: _Transformer?) -> Self?
+    func _plainValue(transformer: _Transformer?) -> Any?
 }

--- a/Source/HelpingMapper.swift
+++ b/Source/HelpingMapper.swift
@@ -102,7 +102,7 @@ public class HelpingMapper {
         self.specify(property: &property, name: nil, converter: converter)
     }
     
-    public func specify<T>(property: inout T, name: String?, converter: ((String) -> T)?) {
+    public func specify<T>(property: inout T, name: String?, converter: ((String) -> T)?, transformer: _Transformer? = nil) {
         let pointer = withUnsafePointer(to: &property, { return $0 })
         let key = Int(bitPattern: pointer)
         let names = (name == nil ? nil : [name!])
@@ -111,7 +111,7 @@ public class HelpingMapper {
             let assignmentClosure = { (jsonValue: Any?) -> Any? in
                 if let _value = jsonValue{
                     if let object = _value as? NSObject {
-                        if let str = String.transform(from: object){
+                        if let str = String.transform(from: object, transformer: transformer){
                             return _converter(str)
                         }
                     }

--- a/Source/Serializer.swift
+++ b/Source/Serializer.swift
@@ -25,16 +25,16 @@ import Foundation
 
 public extension HandyJSON {
 
-    func toJSON() -> [String: Any]? {
-        if let dict = Self._serializeAny(object: self) as? [String: Any] {
+    func toJSON(transformer: _Transformer? = nil) -> [String: Any]? {
+        if let dict = Self._serializeAny(object: self, transformer: transformer) as? [String: Any] {
             return dict
         }
         return nil
     }
 
-    func toJSONString(prettyPrint: Bool = false) -> String? {
+    func toJSONString(prettyPrint: Bool = false, transformer: _Transformer? = nil) -> String? {
 
-        if let anyObject = self.toJSON() {
+        if let anyObject = self.toJSON(transformer: transformer) {
             if JSONSerialization.isValidJSONObject(anyObject) {
                 do {
                     let jsonData: Data
@@ -57,13 +57,13 @@ public extension HandyJSON {
 
 public extension Collection where Iterator.Element: HandyJSON {
 
-    func toJSON() -> [[String: Any]?] {
-        return self.map{ $0.toJSON() }
+    func toJSON(transformer: _Transformer? = nil) -> [[String: Any]?] {
+        return self.map{ $0.toJSON(transformer: transformer) }
     }
 
-    func toJSONString(prettyPrint: Bool = false) -> String? {
+    func toJSONString(prettyPrint: Bool = false, transformer: _Transformer? = nil) -> String? {
 
-        let anyArray = self.toJSON()
+        let anyArray = self.toJSON(transformer: transformer)
         if JSONSerialization.isValidJSONObject(anyArray) {
             do {
                 let jsonData: Data
@@ -77,7 +77,7 @@ public extension Collection where Iterator.Element: HandyJSON {
                 InternalLogger.logError(error)
             }
         } else {
-            InternalLogger.logDebug("\(self.toJSON()) is not a valid JSON Object")
+            InternalLogger.logDebug("\(self.toJSON(transformer: transformer)) is not a valid JSON Object")
         }
         return nil
     }

--- a/Source/Transformable.swift
+++ b/Source/Transformable.swift
@@ -12,38 +12,38 @@ public protocol _Transformable: _Measurable {}
 
 extension _Transformable {
 
-    static func transform(from object: Any) -> Self? {
+    public static func transform(from object: Any, transformer: _Transformer?) -> Self? {
         if let typedObject = object as? Self {
             return typedObject
         }
         switch self {
         case let type as _ExtendCustomBasicType.Type:
-            return type._transform(from: object) as? Self
+            return type._transform(from: object, transformer: transformer) as? Self
         case let type as _BuiltInBridgeType.Type:
-            return type._transform(from: object) as? Self
+            return type._transform(from: object, transformer: transformer) as? Self
         case let type as _BuiltInBasicType.Type:
-            return type._transform(from: object) as? Self
+            return type._transform(from: object, transformer: transformer) as? Self
         case let type as _RawEnumProtocol.Type:
-            return type._transform(from: object) as? Self
+            return type._transform(from: object, transformer: transformer) as? Self
         case let type as _ExtendCustomModelType.Type:
-            return type._transform(from: object) as? Self
+            return type._transform(from: object, transformer: transformer) as? Self
         default:
             return nil
         }
     }
 
-    func plainValue() -> Any? {
+    public func plainValue(transformer: _Transformer?) -> Any? {
         switch self {
         case let rawValue as _ExtendCustomBasicType:
-            return rawValue._plainValue()
+            return rawValue._plainValue(transformer: transformer)
         case let rawValue as _BuiltInBridgeType:
-            return rawValue._plainValue()
+            return rawValue._plainValue(transformer: transformer)
         case let rawValue as _BuiltInBasicType:
-            return rawValue._plainValue()
+            return rawValue._plainValue(transformer: transformer)
         case let rawValue as _RawEnumProtocol:
-            return rawValue._plainValue()
+            return rawValue._plainValue(transformer: transformer)
         case let rawValue as _ExtendCustomModelType:
-            return rawValue._plainValue()
+            return rawValue._plainValue(transformer: transformer)
         default:
             return nil
         }


### PR DESCRIPTION
我们公司的服务端下发的json数据，总是把字典包含在字符串内，如 "{ \\"name\\": true }" 这种形式，导致在解析时，需要针对每个字段实现mapper方法，用起来比较麻烦，希望能增加一个类似transformer的接口，使属性解析时，能优先从传入的transormer接口预解析一遍，解析失败后再执行默认行为。