### PR TITLE
Update HandyJSON.h

### DIFF
--- a/Source/HandyJSON.h
+++ b/Source/HandyJSON.h
@@ -17,7 +17,13 @@
 //  Created by zhouzhuo on 7/11/16.
 //
 
+#if __has_feature(modules)
+
+#if __has_warning("-Watimport-in-framework-header")
+#pragma clang diagnostic ignored "-Watimport-in-framework-header"
+#endif
 @import Foundation;
+#endif
 
 //! Project version number for HandyJSON.
 FOUNDATION_EXPORT double HandyJSONVersionNumber;


### PR DESCRIPTION
Xcode14.3 Report error `use of '@import' in framework header is discouraged, including this header requires -fmodules`

Xcode 11.4 turns the -Watimport-in-framework-header warning on by default. Using @import in framework headers is discouraged, because doing so requires all importers to use modules.

https://developer.apple.com/documentation/xcode-release-notes/xcode-11_4-release-notes