### PR TITLE
handyjson增加类型校验，提高线上稳定性2

### DIFF
--- a/Source/AnyExtensions.swift
+++ b/Source/AnyExtensions.swift
@@ -24,6 +24,13 @@
 protocol AnyExtensions {}
 
 extension AnyExtensions {
+    
+    public func validate(value: Any) -> Bool {
+        guard let _ = value as? Self else {
+            return false
+        }
+        return true
+    }
 
     public static func isValueTypeOrSubtype(_ value: Any) -> Bool {
         return value is Self

--- a/Source/ExtendCustomModelType.swift
+++ b/Source/ExtendCustomModelType.swift
@@ -65,7 +65,7 @@ fileprivate func convertValue(rawValue: Any, property: PropertyInfo, mapper: Hel
 }
 
 fileprivate func assignProperty(convertedValue: Any, instance: _ExtendCustomModelType, property: PropertyInfo) {
-    if property.bridged {
+    if property.bridged, extensions(of: property.type).validate(value: convertedValue) {
         (instance as! NSObject).setValue(convertedValue, forKey: property.key)
     } else {
         extensions(of: property.type).write(convertedValue, to: property.address)


### PR DESCRIPTION
HandyJSON在赋值KVC前没有做类型校验，容易造成线上故障